### PR TITLE
Allow use of current nix (with separate nix file) 

### DIFF
--- a/analyse_seqs.py
+++ b/analyse_seqs.py
@@ -15,6 +15,8 @@ import argparse as argparse
 from sst_dsd import pfunc, binding, mfe_binding, RNAduplex_multiple
 from atam2ssts import eval_colocated_end_pair
 
+import re
+
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from multiprocessing.pool import ThreadPool
@@ -1212,7 +1214,7 @@ def idt_format_line(line):
   return len(line.split(","))==4 and set(line.split(",")[1]).issubset(set("ATCG atcg /iBiodT/"))
 
 def seq_designer_format_line(line):
-  return len(line.split("  "))==2 and set(line.split("  ")[1]).issubset(set("ATCG atcg /iBiodT/"))
+  return len(re.split("\s\s+",line))==2 and set(re.split("\s\s+",line)[1]).issubset(set("ATCG atcg /iBiodT/"))
 
 def seqs_with_no_names_line(line):
   return set(line.replace(" ","")).issubset(set("ATCG atcg /iBiodT/"))
@@ -1293,7 +1295,7 @@ def sequencer_designer_file_format_to_IDT_file_format(input_filename):
       out_file.write(l+"\n") 
 
     if not l.startswith("#") and not l=="":
-      name, sequence = l.split("  ")
+      name, sequence = re.split("\s\s+",l)
 
 
       new_line = name+","+sequence

--- a/default-current-nix.nix
+++ b/default-current-nix.nix
@@ -1,0 +1,64 @@
+
+# Nix script to set up appropriate environment to run python-based SST sequence designer, defaulting to python3. 
+# Type 'nix-shell' to run this script. 
+# 
+# Shipped with DNA single-stranded tile (SST) sequence designer used in the following publication.
+# "Diverse and robust molecular algorithms using reprogrammable DNA self-assembly"
+# Woods*, Doty*, Myhrvold, Hui, Zhou, Yin, Winfree. (*Joint first co-authors). Nature, 2019
+
+with import <nixpkgs>{};  # import nixos packages
+
+let 
+  nupack=stdenv.mkDerivation{
+    name="nupack";
+    #src=./nupack_viennaRNA/nupack3.0.6.tar.gz;  # nix knows to unzip and untar and run make
+    src = fetchurl {
+    url = "http://www.dna.caltech.edu/SupplementaryMaterial/Algorithmic_SST/archived_software/nupack3.0.6.tar.gz";
+    sha256 = "1kv5irz8n57875dgzr5w3zc9xsy8dbvcfk3iszw5ask942dpdpvw";
+    };
+    buildPhase = ''
+        # -fcommon is required for modern versions of gcc to compile nupack3.0.6 without a 
+        # multiple definitions error.
+        export NUPACK_CFLAGS="-std=c99 -O3 -Wall -Wmissing-prototypes -Wmissing-declarations -fcommon"
+        export NUPACK_CXXFLAGS="-Wall -Wmissing-prototypes -Wmissing-declarations -fcommon"
+        CFLAGS=-fcommon make'';
+    installPhase = ''  # installPhase interprets double-quoted string as a bash script
+          mkdir -p $out; # $out is bash variable that nix sets before running this bash script
+          cp -r bin $out;
+          cp -r parameters $out;
+    '';
+  };
+
+  viennaRNA=stdenv.mkDerivation{
+    name="viennaRNA";
+    src = fetchurl {
+    url = "http://www.dna.caltech.edu/SupplementaryMaterial/Algorithmic_SST/archived_software/ViennaRNA-2.1.9.tar.gz";
+    sha256 = "1swjnfir5gx424srsnggw4sf8x0p8kiqfzgzp5m34zdzvn4nlzrn";
+    };
+    # if one has a local copy of the source one can replace the above src instruction with: 
+    # src=./ViennaRNA-2.1.9.tar.gz;
+    buildInputs = with pkgs; [ which perl gnumake ];
+    NIX_CFLAGS_COMPILE = "-fcommon";
+    NIX_CXXFLAGS_COMPILE = "-std=c++14";
+    buildPhase = ''
+      echo "Running the viennaRNA build phase" 
+      export CFLAGS="-fcommon"
+      export CXXFLAGS="-std=c++14"
+      ./configure --prefix=$out --without-perl --without-doc --without-doc-html --without-doc-pdf --without-kinfold --without-svm --without-forester
+      make'';
+    installPhase = ''
+       make install
+      	'';
+  }; in  
+
+stdenv.mkDerivation{
+  name="nupack_viennaRNA";
+  buildInputs = with pkgs; [
+    coreutils
+    (python3.withPackages (ps: [ ps.numpy ps.matplotlib ]))
+    nupack
+    viennaRNA
+  ]; # here I put a list of names of packages I want to install
+  NUPACKHOME = "${nupack.out}";
+  VIENNARNA_PARAMS_PATH="${viennaRNA.out}/share/ViennaRNA/";
+}

--- a/dsd.py
+++ b/dsd.py
@@ -137,7 +137,7 @@ def longest_common_substring(a1, a2, vectorized=True):
     substring (subarray) of 1D arrays a1 and a2.'''
     assert len(a1.shape) == 1
     assert len(a2.shape) == 1
-    counter = np.zeros(shape=(len(a1)+1,len(a2)+1), dtype=np.int)
+    counter = np.zeros(shape=(len(a1)+1,len(a2)+1), dtype=int)
     a1idx_longest = a2idx_longest = -1
     len_longest = 0
 
@@ -175,11 +175,11 @@ def longest_common_substrings_singlea1(a1, a2s):
     numa2s = a2s.shape[0]
     len_a1 = len(a1)
     len_a2 = a2s.shape[1]
-    counter = np.zeros(shape=(len_a1+1, numa2s, len_a2+1), dtype=np.int)
+    counter = np.zeros(shape=(len_a1+1, numa2s, len_a2+1), dtype=int)
 
     for i1 in range(len(a1)):
         idx = (a2s == a1[i1])
-        idx_shifted = np.insert(idx, 0, np.zeros(numa2s, dtype=np.bool), axis=1)
+        idx_shifted = np.insert(idx, 0, np.zeros(numa2s, dtype=bool), axis=1)
         counter[i1+1,idx_shifted] = counter[i1,idx]+1
 
     counter = np.swapaxes(counter, 0, 1)
@@ -228,14 +228,14 @@ def _longest_common_substrings_pairs(a1s, a2s):
     len_a1 = a1s.shape[1]
     len_a2 = a2s.shape[1]
 
-    counter = np.zeros(shape=(len_a1+1, numpairs, len_a2+1), dtype=np.int)
+    counter = np.zeros(shape=(len_a1+1, numpairs, len_a2+1), dtype=int)
 
     for i1 in range(len_a1):
         a1s_cp_col = a1s[:,i1].reshape(numpairs,1)
         a1s_cp_col_rp = np.repeat(a1s_cp_col, len_a2, axis=1)
 
         idx = (a2s == a1s_cp_col_rp)
-        idx_shifted = np.hstack([np.zeros(shape=(numpairs,1), dtype=np.bool), idx])
+        idx_shifted = np.hstack([np.zeros(shape=(numpairs,1), dtype=bool), idx])
         counter[i1+1,idx_shifted] = counter[i1,idx]+1
 
     counter = np.swapaxes(counter, 0, 1)
@@ -265,7 +265,7 @@ def _strongest_common_substrings_all_pairs_return_energies_and_counter(a1s, a2s,
     numpairs = a1s.shape[0]
     len_a1 = a1s.shape[1]
     len_a2 = a2s.shape[1]
-    counter = np.zeros(shape=(len_a1+1, numpairs, len_a2+1), dtype=np.int)
+    counter = np.zeros(shape=(len_a1+1, numpairs, len_a2+1), dtype=int)
     energies = np.zeros(shape=(len_a1+1, numpairs, len_a2+1), dtype=np.float)
 
 #     if not loop_energies:
@@ -279,7 +279,7 @@ def _strongest_common_substrings_all_pairs_return_energies_and_counter(a1s, a2s,
 
         # find matching chars and extend length of substring
         match_idxs = (a2s == a1s_col_rp)
-        match_shifted_idxs = np.hstack([np.zeros(shape=(numpairs,1), dtype=np.bool), match_idxs])
+        match_shifted_idxs = np.hstack([np.zeros(shape=(numpairs,1), dtype=bool), match_idxs])
         counter[i1+1,match_shifted_idxs] = counter[i1,match_idxs] + 1
 
         if i1 > 0:
@@ -289,9 +289,9 @@ def _strongest_common_substrings_all_pairs_return_energies_and_counter(a1s, a2s,
             loops = (prev_bases << 2) + cur_bases
             latest_energies = loop_energies[loops].reshape(numpairs, 1)
             latest_energies_rp = np.repeat(latest_energies, len_a2, axis=1)
-            match_idxs_false_at_end = np.hstack([match_idxs, np.zeros(shape=(numpairs,1), dtype=np.bool)])
+            match_idxs_false_at_end = np.hstack([match_idxs, np.zeros(shape=(numpairs,1), dtype=bool)])
             both_match_idxs = match_idxs_false_at_end & prev_match_shifted_idxs
-            prev_match_shifted_shifted_idxs = np.hstack([np.zeros(shape=(numpairs,1), dtype=np.bool), prev_match_shifted_idxs])[:,:-1]
+            prev_match_shifted_shifted_idxs = np.hstack([np.zeros(shape=(numpairs,1), dtype=bool), prev_match_shifted_idxs])[:,:-1]
             both_match_shifted_idxs = match_shifted_idxs & prev_match_shifted_shifted_idxs
             energies[i1+1,both_match_shifted_idxs] = energies[i1,both_match_idxs] + latest_energies_rp[both_match_idxs]
 
@@ -335,7 +335,7 @@ def _mfes_array(a1s, a2s, T):
     numpairs = a1s.shape[0]
     len_a1 = a1s.shape[1]
     len_a2 = a2s.shape[1]
-    d = np.zeros(shape=(len_a1+1, len_a2+1, numpairs), dtype=np.int)
+    d = np.zeros(shape=(len_a1+1, len_a2+1, numpairs), dtype=int)
     energies = np.zeros(shape=(len_a1+1, len_a2+1, numpairs), dtype=np.float)
 
 #     if not loop_energies:
@@ -717,7 +717,7 @@ class DNASeqList(object):
         subvals = np.dot(subints,powarr)
         toeplitz = create_toeplitz(self.seqlen, sublen)
         convolution = np.dot(toeplitz, self.seqarr.transpose())
-        passall = np.ones(self.numseqs,dtype=np.bool)
+        passall = np.ones(self.numseqs,dtype=bool)
         for subval in subvals:
             passsub = np.all(convolution != subval,axis=0)
             passall = passall & passsub
@@ -744,7 +744,7 @@ def create_toeplitz(seqlen,sublen):
     else: #This is a fix for the fact that numpypy doesn't have scipy.
         rows = seqlen-(sublen-1)
         cols = seqlen
-        toeplitz = np.zeros((rows,cols),dtype=np.int)
+        toeplitz = np.zeros((rows,cols),dtype=int)
         toeplitz[:,0:sublen] = [powarr]*rows
         shift = list(range(rows))
         for i in range(rows):


### PR DESCRIPTION
This pull request (which includes #4 and #5) makes minimal changes to code to allow the package to work with current Numpy versions, and thus, to work, as of 2023-10, with current Nix packages.  It uses the current nix channel when `default-current-nix.nix` is used instead of `default.nix`, eg, with

```sh
nix-shell default-current-nix.nix
```

This approach works with Linux (Fedora 39 x64), but is in particular more likely to work with ARM-based Macs, which were not supported by Nix at the point in 2019 that `default.nix` references.